### PR TITLE
Fix logging in Exchange of invalid message flow

### DIFF
--- a/src/main/java/eu/europa/ec/fisheries/uvms/exchange/model/mapper/ExchangeModuleRequestMapper.java
+++ b/src/main/java/eu/europa/ec/fisheries/uvms/exchange/model/mapper/ExchangeModuleRequestMapper.java
@@ -92,11 +92,11 @@ public class ExchangeModuleRequestMapper {
         return JAXBMarshaller.marshallJaxBObjectToString(receiveSalesResponseRequest);
     }
 
-    public static String createReceiveInvalidSalesMessage(String respondToInvalidMessageRequest, String userName) throws ExchangeModelMarshallException {
+    public static String createReceiveInvalidSalesMessage(String respondToInvalidMessageRequest, String guid, String sender, Date date, String username, PluginType pluginType) throws ExchangeModelMarshallException {
         ReceiveInvalidSalesMessage receiveInvalidSalesMessage = new ReceiveInvalidSalesMessage();
         receiveInvalidSalesMessage.setRespondToInvalidMessageRequest(respondToInvalidMessageRequest);
-        receiveInvalidSalesMessage.setUsername(userName);
-        receiveInvalidSalesMessage.setMethod(ExchangeModuleMethod.RECEIVE_INVALID_SALES_MESSAGE);
+
+        enrichBaseRequest(receiveInvalidSalesMessage, ExchangeModuleMethod.RECEIVE_INVALID_SALES_MESSAGE, guid, null, sender, date, username, pluginType);
 
         return JAXBMarshaller.marshallJaxBObjectToString(receiveInvalidSalesMessage);
     }


### PR DESCRIPTION
When receiving a sales message that is not compliant to the XSD, this message did not get logged properly in the log table of Exchange. This is a fix for this problem.