### PR TITLE
Make communication with FLUXVESSEL-PLUGIN possible

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
         <groupId>fish.focus.uvms.maven</groupId>
         <artifactId>uvms-pom</artifactId>
         <relativePath />
-        <version>1.14</version>
+        <version>1.17</version>
     </parent>
 
     <groupId>eu.europa.ec.fisheries.uvms.exchange</groupId>

--- a/src/main/java/eu/europa/ec/fisheries/uvms/exchange/model/mapper/ExchangeModuleRequestMapper.java
+++ b/src/main/java/eu/europa/ec/fisheries/uvms/exchange/model/mapper/ExchangeModuleRequestMapper.java
@@ -13,27 +13,7 @@ package eu.europa.ec.fisheries.uvms.exchange.model.mapper;
 
 import eu.europa.ec.fisheries.schema.exchange.common.v1.CommandType;
 import eu.europa.ec.fisheries.schema.exchange.common.v1.CommandTypeType;
-import eu.europa.ec.fisheries.schema.exchange.module.v1.ExchangeBaseRequest;
-import eu.europa.ec.fisheries.schema.exchange.module.v1.ExchangeModuleMethod;
-import eu.europa.ec.fisheries.schema.exchange.module.v1.GetServiceListRequest;
-import eu.europa.ec.fisheries.schema.exchange.module.v1.ProcessedMovementResponse;
-import eu.europa.ec.fisheries.schema.exchange.module.v1.RcvFLUXFaResponseMessageRequest;
-import eu.europa.ec.fisheries.schema.exchange.module.v1.ReceiveInvalidSalesMessage;
-import eu.europa.ec.fisheries.schema.exchange.module.v1.ReceiveSalesQueryRequest;
-import eu.europa.ec.fisheries.schema.exchange.module.v1.ReceiveSalesReportRequest;
-import eu.europa.ec.fisheries.schema.exchange.module.v1.ReceiveSalesResponseRequest;
-import eu.europa.ec.fisheries.schema.exchange.module.v1.SendMovementToPluginRequest;
-import eu.europa.ec.fisheries.schema.exchange.module.v1.SendSalesReportRequest;
-import eu.europa.ec.fisheries.schema.exchange.module.v1.SendSalesResponseRequest;
-import eu.europa.ec.fisheries.schema.exchange.module.v1.SetCommandRequest;
-import eu.europa.ec.fisheries.schema.exchange.module.v1.SetFAQueryMessageRequest;
-import eu.europa.ec.fisheries.schema.exchange.module.v1.SetFLUXFAReportMessageRequest;
-import eu.europa.ec.fisheries.schema.exchange.module.v1.SetFLUXFAResponseMessageRequest;
-import eu.europa.ec.fisheries.schema.exchange.module.v1.SetFLUXMDRSyncMessageExchangeRequest;
-import eu.europa.ec.fisheries.schema.exchange.module.v1.SetFLUXMDRSyncMessageExchangeResponse;
-import eu.europa.ec.fisheries.schema.exchange.module.v1.SetMovementReportRequest;
-import eu.europa.ec.fisheries.schema.exchange.module.v1.UpdateLogStatusRequest;
-import eu.europa.ec.fisheries.schema.exchange.module.v1.UpdatePluginSettingRequest;
+import eu.europa.ec.fisheries.schema.exchange.module.v1.*;
 import eu.europa.ec.fisheries.schema.exchange.movement.v1.MovementRefType;
 import eu.europa.ec.fisheries.schema.exchange.movement.v1.MovementType;
 import eu.europa.ec.fisheries.schema.exchange.movement.v1.RecipientInfoType;
@@ -57,6 +37,8 @@ import java.util.Date;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static eu.europa.ec.fisheries.schema.exchange.module.v1.ExchangeModuleMethod.RECEIVE_ASSET_INFORMATION;
 
 public class ExchangeModuleRequestMapper {
 
@@ -94,6 +76,18 @@ public class ExchangeModuleRequestMapper {
         request.setRequest(message);
         request.setDate(date);
         populateBaseProperties(request, fluxDFValue, date, messageGuid, pluginType, senderReceiver, onValue, username);
+        return JAXBMarshaller.marshallJaxBObjectToString(request);
+    }
+
+
+    public static String createReceiveAssetInformation(String message, String username) throws ExchangeModelMarshallException {
+        ReceiveAssetInformationRequest request = new ReceiveAssetInformationRequest();
+        request.setAssets(message);
+        request.setUsername(username);
+        request.setMethod(RECEIVE_ASSET_INFORMATION);
+        request.setSenderOrReceiver("flux-vessel-plugin");
+        request.setDate(new Date());
+
         return JAXBMarshaller.marshallJaxBObjectToString(request);
     }
 

--- a/src/main/java/eu/europa/ec/fisheries/uvms/exchange/model/mapper/ExchangeModuleRequestMapper.java
+++ b/src/main/java/eu/europa/ec/fisheries/uvms/exchange/model/mapper/ExchangeModuleRequestMapper.java
@@ -38,7 +38,9 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static eu.europa.ec.fisheries.schema.exchange.module.v1.ExchangeModuleMethod.QUERY_ASSET_INFORMATION;
 import static eu.europa.ec.fisheries.schema.exchange.module.v1.ExchangeModuleMethod.RECEIVE_ASSET_INFORMATION;
+import static eu.europa.ec.fisheries.schema.exchange.module.v1.ExchangeModuleMethod.SEND_ASSET_INFORMATION;
 
 public class ExchangeModuleRequestMapper {
 
@@ -80,11 +82,33 @@ public class ExchangeModuleRequestMapper {
     }
 
 
-    public static String createReceiveAssetInformation(String message, String username) throws ExchangeModelMarshallException {
+    public static String createReceiveAssetInformation(String assets, String username) throws ExchangeModelMarshallException {
         ReceiveAssetInformationRequest request = new ReceiveAssetInformationRequest();
-        request.setAssets(message);
+        request.setAssets(assets);
         request.setUsername(username);
         request.setMethod(RECEIVE_ASSET_INFORMATION);
+        request.setSenderOrReceiver("flux-vessel-plugin");
+        request.setDate(new Date());
+
+        return JAXBMarshaller.marshallJaxBObjectToString(request);
+    }
+
+    public static String createSendAssetInformation(String assets, String username) throws ExchangeModelMarshallException {
+        SendAssetInformationRequest request = new SendAssetInformationRequest();
+        request.setAssets(assets);
+        request.setUsername(username);
+        request.setMethod(SEND_ASSET_INFORMATION);
+        request.setSenderOrReceiver("flux-vessel-plugin");
+        request.setDate(new Date());
+
+        return JAXBMarshaller.marshallJaxBObjectToString(request);
+    }
+
+    public static String createQueryAssetInformation(String assets, String username) throws ExchangeModelMarshallException {
+        QueryAssetInformationRequest request = new QueryAssetInformationRequest();
+        request.setAssets(assets);
+        request.setUsername(username);
+        request.setMethod(QUERY_ASSET_INFORMATION);
         request.setSenderOrReceiver("flux-vessel-plugin");
         request.setDate(new Date());
 

--- a/src/main/resources/contract/Exchange.xsd
+++ b/src/main/resources/contract/Exchange.xsd
@@ -87,6 +87,8 @@
             <xsd:enumeration value="SEND_FA_QUERY_MSG"/>
             <xsd:enumeration value="RECEIVE_FA_QUERY_MSG"/>
             <xsd:enumeration value="RECEIVE_ASSET_INFORMATION"/>
+            <xsd:enumeration value="SEND_ASSET_INFORMATION"/>
+            <xsd:enumeration value="QUERY_ASSET_INFORMATION"/>
         </xsd:restriction>
     </xsd:simpleType>
 

--- a/src/main/resources/contract/Exchange.xsd
+++ b/src/main/resources/contract/Exchange.xsd
@@ -86,6 +86,7 @@
             <xsd:enumeration value="SEND_FLUX_RESPONSE_MSG"/>
             <xsd:enumeration value="SEND_FA_QUERY_MSG"/>
             <xsd:enumeration value="RECEIVE_FA_QUERY_MSG"/>
+            <xsd:enumeration value="RECEIVE_ASSET_INFORMATION"/>
         </xsd:restriction>
     </xsd:simpleType>
 
@@ -109,6 +110,7 @@
             <xsd:enumeration value="FA_QUERY"/>
             <xsd:enumeration value="FA_REPORT"/>
             <xsd:enumeration value="FA_RESPONSE"/>
+            <xsd:enumeration value="ASSETS"/>
         </xsd:restriction>
     </xsd:simpleType>
 

--- a/src/main/resources/contract/ExchangeModuleService.wsdl
+++ b/src/main/resources/contract/ExchangeModuleService.wsdl
@@ -35,6 +35,7 @@
                     <xsd:enumeration value="RECEIVE_SALES_QUERY"/>
                     <xsd:enumeration value="RECEIVE_SALES_RESPONSE"/>
                     <xsd:enumeration value="RECEIVE_INVALID_SALES_MESSAGE"/> <!-- XSD validation of message failed -->
+                    <xsd:enumeration value="RECEIVE_ASSET_INFORMATION"/>
 
                     <!-- admin/config wants to-->
                     <xsd:enumeration value="PING"/>

--- a/src/main/resources/contract/ExchangeModuleService.wsdl
+++ b/src/main/resources/contract/ExchangeModuleService.wsdl
@@ -176,6 +176,18 @@
                 </xsd:complexType>
             </xsd:element>
 
+            <xsd:element name="ReceiveAssetInformationRequest">
+                <xsd:complexType>
+                    <xsd:complexContent>
+                        <xsd:extension base="module:ExchangeBaseRequest">
+                            <xsd:sequence>
+                                <xsd:element name="assets" type="xsd:string"/>
+                            </xsd:sequence>
+                        </xsd:extension>
+                    </xsd:complexContent>
+                </xsd:complexType>
+            </xsd:element>
+
 			<xsd:element name="SetFLUXFAResponseMessageRequest">
 				<xsd:complexType>
 					<xsd:complexContent>

--- a/src/main/resources/contract/ExchangeModuleService.wsdl
+++ b/src/main/resources/contract/ExchangeModuleService.wsdl
@@ -36,6 +36,8 @@
                     <xsd:enumeration value="RECEIVE_SALES_RESPONSE"/>
                     <xsd:enumeration value="RECEIVE_INVALID_SALES_MESSAGE"/> <!-- XSD validation of message failed -->
                     <xsd:enumeration value="RECEIVE_ASSET_INFORMATION"/>
+                    <xsd:enumeration value="SEND_ASSET_INFORMATION"/>
+                    <xsd:enumeration value="QUERY_ASSET_INFORMATION"/>
 
                     <!-- admin/config wants to-->
                     <xsd:enumeration value="PING"/>
@@ -177,6 +179,30 @@
             </xsd:element>
 
             <xsd:element name="ReceiveAssetInformationRequest">
+                <xsd:complexType>
+                    <xsd:complexContent>
+                        <xsd:extension base="module:ExchangeBaseRequest">
+                            <xsd:sequence>
+                                <xsd:element name="assets" type="xsd:string"/>
+                            </xsd:sequence>
+                        </xsd:extension>
+                    </xsd:complexContent>
+                </xsd:complexType>
+            </xsd:element>
+
+            <xsd:element name="SendAssetInformationRequest">
+                <xsd:complexType>
+                    <xsd:complexContent>
+                        <xsd:extension base="module:ExchangeBaseRequest">
+                            <xsd:sequence>
+                                <xsd:element name="assets" type="xsd:string"/>
+                            </xsd:sequence>
+                        </xsd:extension>
+                    </xsd:complexContent>
+                </xsd:complexType>
+            </xsd:element>
+
+            <xsd:element name="QueryAssetInformationRequest">
                 <xsd:complexType>
                     <xsd:complexContent>
                         <xsd:extension base="module:ExchangeBaseRequest">

--- a/src/main/resources/contract/ExchangePluginService.wsdl
+++ b/src/main/resources/contract/ExchangePluginService.wsdl
@@ -77,6 +77,30 @@
                 </xsd:complexType>
             </xsd:element>
 
+            <xsd:element name="SendAssetInformationRequest">
+                <xsd:complexType>
+                    <xsd:complexContent>
+                        <xsd:extension base="plugin:PluginBaseRequest">
+                            <xsd:sequence>
+                                <xsd:element name="request" type="xsd:string"/>
+                            </xsd:sequence>
+                        </xsd:extension>
+                    </xsd:complexContent>
+                </xsd:complexType>
+            </xsd:element>
+
+            <xsd:element name="SendQueryAssetInformationRequest">
+                <xsd:complexType>
+                    <xsd:complexContent>
+                        <xsd:extension base="plugin:PluginBaseRequest">
+                            <xsd:sequence>
+                                <xsd:element name="query" type="xsd:string"/>
+                            </xsd:sequence>
+                        </xsd:extension>
+                    </xsd:complexContent>
+                </xsd:complexType>
+            </xsd:element>
+
 			<xsd:element name="SetMdrPluginRequest">
 				<xsd:complexType>
 					<xsd:complexContent>

--- a/src/main/resources/contract/ExchangePluginService.wsdl
+++ b/src/main/resources/contract/ExchangePluginService.wsdl
@@ -30,6 +30,8 @@
 					<xsd:enumeration value="SET_FLUX_RESPONSE"/>
 					<xsd:enumeration value="SEND_SALES_REPORT"/>
 					<xsd:enumeration value="SEND_SALES_RESPONSE"/>
+                    <xsd:enumeration value="SEND_VESSEL_INFORMATION"/>
+                    <xsd:enumeration value="SEND_VESSEL_QUERY"/>
                 </xsd:restriction>
             </xsd:simpleType>
             


### PR DESCRIPTION
Extend Exchange-model to support

- receiving vessel information from fleet
- sending queries to fleet
- sending vessel information to fleet (as response to the query)
