### PR TITLE
Fix log for sales in exchange

### DIFF
--- a/src/main/java/eu/europa/ec/fisheries/uvms/exchange/model/mapper/ExchangeModuleRequestMapper.java
+++ b/src/main/java/eu/europa/ec/fisheries/uvms/exchange/model/mapper/ExchangeModuleRequestMapper.java
@@ -179,13 +179,19 @@ public class ExchangeModuleRequestMapper {
     }
 
     public static String createReceiveInvalidSalesMessage(String respondToInvalidMessageRequest, String guid, String sender, Date date, String username, PluginType pluginType) throws ExchangeModelMarshallException {
+        return createReceiveInvalidSalesMessage(respondToInvalidMessageRequest, guid, sender,
+                date, username, pluginType, null);
+    }
+
+    public static String createReceiveInvalidSalesMessage(String respondToInvalidMessageRequest, String guid, String sender, Date date, String username, PluginType pluginType, String originalMessage) throws ExchangeModelMarshallException {
         ReceiveInvalidSalesMessage receiveInvalidSalesMessage = new ReceiveInvalidSalesMessage();
         receiveInvalidSalesMessage.setRespondToInvalidMessageRequest(respondToInvalidMessageRequest);
-
+        receiveInvalidSalesMessage.setOriginalMessage(originalMessage);
         enrichBaseRequest(receiveInvalidSalesMessage, ExchangeModuleMethod.RECEIVE_INVALID_SALES_MESSAGE, guid, null, sender, date, username, pluginType, null);
 
         return JAXBMarshaller.marshallJaxBObjectToString(receiveInvalidSalesMessage);
     }
+
 
     /**
      @deprecated use createSendSalesResponseRequest(String response,

--- a/src/main/resources/contract/ExchangeModuleService.wsdl
+++ b/src/main/resources/contract/ExchangeModuleService.wsdl
@@ -151,6 +151,7 @@
                         <xsd:extension base="module:ExchangeBaseRequest">
                             <xsd:sequence>
                                 <xsd:element name="respondToInvalidMessageRequest" type="xsd:string"/>
+                                <xsd:element name="originalMessage" type="xsd:string" minOccurs="0"/>
                             </xsd:sequence>
                         </xsd:extension>
                     </xsd:complexContent>


### PR DESCRIPTION
In case of an xsd-invalid sales message, the message was not logged correctly in Exchange. This pull request fixes that issue.